### PR TITLE
Use packer to build custom centos 9 AMI

### DIFF
--- a/packer/centos_9_arm64.pkr.hcl
+++ b/packer/centos_9_arm64.pkr.hcl
@@ -1,0 +1,36 @@
+locals {
+  creation_date = formatdate("YYYY-MM-DD", timestamp())
+}
+
+source "amazon-ebs" "centos" {
+  ami_name      = "centos-9-arm64-${local.creation_date}"
+  instance_type = "t4g.micro"
+  region        = "us-east-1"
+  ssh_username = "centos"
+
+  source_ami_filter {
+    filters = {
+      name                = "CentOS Stream 9*"
+      architecture        = "arm64"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["125523088429"]
+  }
+
+}
+
+build {
+  name = "build"
+  sources = [
+    "source.amazon-ebs.centos"
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "sudo dnf update -y",
+      "sudo sed -i 's/cloud_config_modules:/&\\n - yum_add_repo/' /etc/cloud/cloud.cfg",
+    ]
+  }
+}

--- a/packer/config.pkr.hcl
+++ b/packer/config.pkr.hcl
@@ -1,0 +1,8 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.1.1"
+      source = "github.com/hashicorp/amazon"
+    }
+  }
+}

--- a/terraform/modules/compute/data.tf
+++ b/terraform/modules/compute/data.tf
@@ -41,3 +41,18 @@ data "aws_ami" "ubuntu_22_04" {
 
   owners = ["099720109477"] # Canonical
 }
+
+data "aws_ami" "my_centos_9" {
+  most_recent = true
+  owners      = ["self"]
+
+  filter {
+    name   = "name"
+    values = ["centos-9-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+}

--- a/terraform/modules/compute/ec2_cluster_coordinator.tf
+++ b/terraform/modules/compute/ec2_cluster_coordinator.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "cluster_coordinators" {
-  ami                  = data.aws_ami.ubuntu_22_04.id
+  ami                  = data.aws_ami.my_centos_9.id
   iam_instance_profile = var.coordinator_instance_profile
   instance_type        = var.coordinator_instance_type
   user_data            = var.coordinator_user_data
@@ -17,10 +17,6 @@ resource "aws_instance" "cluster_coordinators" {
   tags = {
     Name             = format("%s-coordinator-%d", var.cluster_identifier, count.index + 1)
     ConsulDatacenter = var.cluster_identifier
-  }
-
-  lifecycle {
-    ignore_changes = [ami]
   }
 
   count = var.coordinator_instance_count

--- a/terraform/modules/compute/ec2_cluster_worker.tf
+++ b/terraform/modules/compute/ec2_cluster_worker.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "cluster_worker" {
-  ami                  = data.aws_ami.ubuntu_22_04.id
+  ami                  = data.aws_ami.my_centos_9.id
   iam_instance_profile = var.worker_instance_profile
   instance_type        = var.worker_instance_type
   user_data            = var.worker_user_data
@@ -17,10 +17,6 @@ resource "aws_instance" "cluster_worker" {
   tags = {
     Name             = format("%s-worker-%d", var.cluster_identifier, count.index + 1)
     ConsulDatacenter = var.cluster_identifier
-  }
-
-  lifecycle {
-    ignore_changes = [ami]
   }
 
   count = var.worker_instance_count

--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+readonly GIT_ROOT=$(git rev-parse --show-toplevel)
+
 # ACG doesn't support us-east-2
 export AWS_REGION=us-east-1
 
+packer build "$GIT_ROOT/packer"
 
 readonly hostedZones=$(aws route53 list-hosted-zones \
     | jq -r '.HostedZones | map("  " + .Name)[]')


### PR DESCRIPTION
For some reason (I presume it's a mistake, but currently unsure), the
latest public centos 9 image doesn't include the cloud-init module to
configure extra yum repos. Because we need this to get Consul and Nomad,
that makes the public image unuseable for us.

We could use a different public image like ubuntu, but centos has seemed
to build/boot much faster, and I value that. Instead, I've simply
created a custom image that enables the cloud-init module we need (and
also installs package updates, so first boot of our cluster is a little
bit faster).